### PR TITLE
chore(renovate): stop go.mod directive bumps, fix invalid action rule

### DIFF
--- a/renovate/preset.json
+++ b/renovate/preset.json
@@ -103,6 +103,10 @@
       "enabled": false
     },
     {
+      "description": "Normalize GitHub Action tag versions (e.g. v4 vs v4.1.2) so they compare correctly.",
+      "matchManagers": [
+        "github-actions"
+      ],
       "extractVersion": "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },

--- a/renovate/preset.json
+++ b/renovate/preset.json
@@ -93,6 +93,16 @@
       "rangeStrategy": "replace"
     },
     {
+      "description": "Do not bump the go directive/toolchain in go.mod. For libraries this needlessly raises the minimum go version for consumers; the .go-version file still drives the CI toolchain.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "enabled": false
+    },
+    {
       "extractVersion": "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },


### PR DESCRIPTION
## What

Two small fixes to the shared Renovate preset:

1. **Stop bumping the `go` directive in `go.mod`.** A packageRule that disables `golang-version` updates from the `gomod` manager only.
2. **Fix an invalid (and accidentally global) packageRule.** The action version-normalize rule lost its `match*` selector and is now scoped back to `github-actions`.

## Why

**(1)** Renovate's gomod manager treats the `go` directive as a `golang-version` dependency and bumps it (that's where `go 1.26.5` got pushed into a library go.mod). For a library the directive is the *minimum* Go version, so raising it locks out consumers on older toolchains for no benefit. Scoping the disable to `matchManagers: ["gomod"]` leaves the `.go-version` custom manager (which drives the CI toolchain) working.

**(2)** While here I fixed the pre-existing validator error. That rule (`extractVersion` + `regex:` versioning for `v4` vs `v4.1.2` tags) originally extended `helpers:pinGitHubActionDigests`, which gave it a `matchDepTypes: ["action"]` selector. That `extends` was dropped at some point (commit d604582 added it *with* the extends; it's gone now), leaving no selector, so it applied the regex versioning to **every** dependency and current Renovate rejects it. Re-scoped it explicitly to `github-actions`. Digest pinning is unaffected (still applied via the top-level `extends`).

## Testing

```
$ renovate-config-validator renovate/preset.json
 INFO: Config validated successfully
```

(Was failing before on `packageRules[...]: Each packageRule must contain at least one match* or exclude* selector`.)

